### PR TITLE
Fixed command prefix, no longer uses >, instead uses /command

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -137,9 +137,9 @@ class MyClient(discord.Client):
                 msg = fl.readlines()
                 index = random.randint(0, len(msg) - 1)
                 await message.channel.send(msg[index])
-            elif message.content.startswith(">"):
+            elif message.content.startswith("/command"):
                 # Remove the `>`
-                command = message.content[1:].strip()
+                command = message.content[8:].strip()
                 print("Got command: \"" + command + "\"")
                 command_output = bot_commands.exec_command(command)
                 await message.channel.send("[Host Machine: " + \


### PR DESCRIPTION
Changed the command prefix to now use /command instead of >.